### PR TITLE
Make File.Many be able to be instantiated without a fileExtension

### DIFF
--- a/Sources/FileTree/Conversions.swift
+++ b/Sources/FileTree/Conversions.swift
@@ -76,13 +76,6 @@ extension FileTreeComponent {
 
 
 
-//
-func foo() {
-
-    let x = File.Many(withExtension: "txt")
-        .convert(Conversions.Identity())
-}
-
 extension FileTreeComponent where Content: Collection {
     public func map<NewContent, C>(
         _ conversion: C


### PR DESCRIPTION
This allows it to grab files of every type.